### PR TITLE
Add break to a case label

### DIFF
--- a/src/mod_pam_nam.c
+++ b/src/mod_pam_nam.c
@@ -43,6 +43,7 @@ write_config_nam (pam_module_t * this, enum write_type op, FILE * fp)
       break;
     case AUTH:
       fprintf (fp, "auth\trequired\tpam_nam.so\tuse_first_pass\n");
+      break;
     case PASSWORD:
       fprintf (fp, "password\trequired\tpam_nam.so\ttry_first_pass\n");
       break;


### PR DESCRIPTION
GCC 7 error:
mod_pam_nam.c:45:7: error: this statement may fall through
[-Werror=implicit-fallthrough=]