### PR TITLE
Include pam_systemd in common-session-pc by default

### DIFF
--- a/src/pam-config.c
+++ b/src/pam-config.c
@@ -1001,6 +1001,8 @@ main (int argc, char *argv[])
       opt_set->enable (opt_set, "is_enabled", opt.opt_val);
       opt_set = mod_pam_umask.get_opt_set (&mod_pam_umask, SESSION);
       opt_set->enable (opt_set, "is_enabled", opt.opt_val);
+      opt_set = mod_pam_systemd.get_opt_set (&mod_pam_systemd, SESSION);
+      opt_set->enable (opt_set, "is_enabled", opt.opt_val);
       if (sanitize_check_session (common_module_list, 0) != 0)
 	return 1;
 


### PR DESCRIPTION
Since Since boo#812462, pam_systemd module is included by default in
common-session.

Therefore it also makes sense for pam-config to add it by default when
it create a new common-session (via pam-config --create).