### PR TITLE
Remove bad "access" call and handle failing "stat" call properly.

### DIFF
--- a/src/mod_pam_keyinit.c
+++ b/src/mod_pam_keyinit.c
@@ -47,20 +47,15 @@ write_config_keyinit (pam_module_t *this,
   fp = create_service_file (gl_service);
   if (!fp) return 0;
 
-  fprintf(stderr, "writeit=%d, is_written=%d\n", writeit, is_written);
   while (cfg_content != NULL)
   {
-    fprintf(stderr, "cfg_content->line = >>%s", cfg_content->line);
     if (writeit)
     {
-      fprintf(stderr, "writeit=%d\n", writeit);
       if (!is_written)
       {
-	fprintf(stderr, "is_written=%d\n", is_written);
 	/* write this entry as the first in the session part */
 	if (strstr(cfg_content->line, "session") != NULL)
 	{
-	  fprintf(stderr, "strstr(cfg_content->line, \"session\") != NULL\n");
 	  write_entry(fp, opt_set);
 	  is_written = 1;
 	}
@@ -97,7 +92,6 @@ write_config_keyinit (pam_module_t *this,
 static void
 write_entry(FILE *fp, option_set_t *opt_set)
 {
-  fprintf(stderr, "write_entry(fp, opt_set)\n");
   fprintf (fp, "session  optional\tpam_keyinit.so revoke ");
   if (opt_set->is_enabled (opt_set, "force"))
     fprintf (fp, "force ");
@@ -121,7 +115,7 @@ PRINT_ARGS("keyinit")
 PRINT_XMLHELP("keyinit")
 
 /* ---- contruct module object ---- */
-DECLARE_BOOL_OPTS_3 (is_enabled, debug, force);
+DECLARE_BOOL_OPTS_4 (is_enabled, debug, force, revoke);
 DECLARE_STRING_OPTS_0;
 DECLARE_OPT_SETS;
 

--- a/src/pam-config.c
+++ b/src/pam-config.c
@@ -1085,19 +1085,10 @@ main (int argc, char *argv[])
       if (debug)
 		  printf ("*** write_config (%s/pam.d/%s)\n", confdir, gl_service);
 
-      /* Check if service file exists */
-      char *conffile;
-      if (asprintf (&conffile, "%s/pam.d/%s", confdir, gl_service) < 0)
-	return 1;
-
-      if (access (conffile, R_OK) != 0)
-      {
-	fprintf (stderr, _("Cannot access '%s': %m\n"), conffile);
-	free (conffile);
-	return 1;
-      }
-      free (conffile);
-
+      /*
+       * Note that the modules in service_module_list[]
+       * do not use the "op" and the "fp" parameters.
+       */
       while (*modptr != NULL)
 	{
 	  retval |= (*modptr)->write_config (*modptr, -1, NULL);

--- a/src/single_config.c
+++ b/src/single_config.c
@@ -245,12 +245,15 @@ create_service_file (const char *service)
     return NULL;
 
   if (stat (conffile, &f_stat) != 0)
-  {
-    fprintf (stderr, _("Cannot stat '%s': %m\n"), conffile);
-    free (tmp_file);
-    free (conffile);
-    return NULL;
-  }
+    {
+      /* Make them owned by root and writable only by root */
+      fprintf (stderr, _("Cannot stat '%s': %m\n"), conffile);
+
+      memset(&f_stat, 0, sizeof(struct stat));	/* To be on the safe side ... */
+      f_stat.st_mode = 0644;
+      f_stat.st_uid = 0;
+      f_stat.st_gid = 0;
+    }
 
   free (conffile);
   fd = mkstemp (tmp_file);


### PR DESCRIPTION
Prior to writing an service-specific config file, the main function
calls access() on the destination file in /etc/pam.d.
This will fail and no config file will be written when the original
config file was installed in /usr/etc/pam.d.
A similar problem exists when creating the new service file:
create_service_file() wants to give the new service file the same
user, group and mode as the old one, but the old one may not exist.
In that case, set these to 0(root), 0(root), and 0644.

Also added "revoke" to the option list for pam_keyinit