### PR TITLE
load_single_config: try to read vendor file if not exists at /etc dir

### DIFF
--- a/src/single_config.c
+++ b/src/single_config.c
@@ -48,6 +48,26 @@ load_single_config (const char *config_name, config_content_t **ptr)
   if (debug)
     printf ("*** load_single_config (%s)\n", file);
 
+  // Check if files exists or need to load from vendor path
+  if (access(file, F_OK) < 0)
+    {
+      free(file);
+      file = NULL;
+      if (asprintf (&file, "%s/pam.d/%s", CONF_FALLBACK_DIR2, config_name) < 0)
+        return -1;
+      if (debug)
+        printf ("*** Trying %s...\n", file);
+    }
+  if (access(file, F_OK) < 0)
+    {
+      free(file);
+      file = NULL;
+      if (asprintf (&file, "%s/pam.d/%s", CONF_FALLBACK_DIR1, config_name) < 0)
+        return -1;
+      if (debug)
+        printf ("*** Trying %s...\n", file);
+    }
+
   fp = fopen(file, "r");
   if (fp == NULL)
     {


### PR DESCRIPTION
	* fix bsc#1196613. If no file at /etc/pam.d trying to find a reference file at vendor directories (/usr/etc/pam.d or /usr/lib/pam.d)

Signed-off-by: Valentin Lefebvre <valentin.lefebvre@suse.com>