### PR TITLE
pam_systemd reduction

### DIFF
--- a/src/pam-config.c
+++ b/src/pam-config.c
@@ -1059,6 +1059,9 @@ main (int argc, char *argv[])
 
       if (write_config (confdir, CONF_SESSION_PC, SESSION, module_list_session) != 0)
 	return 1;
+
+      if (write_config (confdir, CONF_SESSION_NONLOGIN_PC, SESSION, module_list_session) != 0)
+	return 1;
     }
   else if (!gl_service)
     {
@@ -1089,6 +1092,9 @@ main (int argc, char *argv[])
 	return 1;
 
       if (write_config (confdir, CONF_SESSION_PC, SESSION, module_list_session) != 0)
+	return 1;
+
+      if (write_config (confdir, CONF_SESSION_NONLOGIN_PC, SESSION, module_list_session) != 0)
 	return 1;
     }
   else
@@ -1124,6 +1130,9 @@ main (int argc, char *argv[])
       if (relink (confdir, CONF_SESSION, CONF_SESSION_PC) != 0)
 	retval = 1;
 
+      if (relink (confdir, CONF_SESSION_NONLOGIN, CONF_SESSION_NONLOGIN_PC) != 0)
+	retval = 1;
+
       if (opt.m_init && retval == 0)
 	{
 	  rename ("/etc/security/pam_pwcheck.conf",
@@ -1146,6 +1155,9 @@ main (int argc, char *argv[])
 
       if (relink (confdir, CONF_SESSION, CONF_SESSION_PC) != 0)
 	retval = 1;
+
+      if (relink (confdir, CONF_SESSION_NONLOGIN, CONF_SESSION_NONLOGIN_PC) != 0)
+	retval = 1;
     }
 
   if (!gl_service)
@@ -1157,6 +1169,8 @@ main (int argc, char *argv[])
       if (check_symlink (confdir, CONF_PASSWORD_PC, CONF_PASSWORD) != 0)
 	retval = 1;
       if (check_symlink (confdir, CONF_SESSION_PC, CONF_SESSION) != 0)
+	retval = 1;
+      if (check_symlink (confdir, CONF_SESSION_NONLOGIN_PC, CONF_SESSION_NONLOGIN) != 0)
 	retval = 1;
     }
 

--- a/src/pam-config.c
+++ b/src/pam-config.c
@@ -1060,7 +1060,7 @@ main (int argc, char *argv[])
       if (write_config (confdir, CONF_SESSION_PC, SESSION, module_list_session) != 0)
 	return 1;
 
-      if (write_config (confdir, CONF_SESSION_NONLOGIN_PC, SESSION, module_list_session) != 0)
+      if (write_config (confdir, CONF_SESSION_NONLOGIN_PC, SESSION, module_list_session_nl) != 0)
 	return 1;
     }
   else if (!gl_service)
@@ -1094,7 +1094,7 @@ main (int argc, char *argv[])
       if (write_config (confdir, CONF_SESSION_PC, SESSION, module_list_session) != 0)
 	return 1;
 
-      if (write_config (confdir, CONF_SESSION_NONLOGIN_PC, SESSION, module_list_session) != 0)
+      if (write_config (confdir, CONF_SESSION_NONLOGIN_PC, SESSION, module_list_session_nl) != 0)
 	return 1;
     }
   else

--- a/src/pam-config.h
+++ b/src/pam-config.h
@@ -52,6 +52,8 @@ extern char *confdir;
 #define CONF_PASSWORD_PC "common-password-pc"
 #define CONF_SESSION "common-session"
 #define CONF_SESSION_PC "common-session-pc"
+#define CONF_SESSION_NONLOGIN "common-session-nonlogin"
+#define CONF_SESSION_NONLOGIN_PC "common-session-nonlogin-pc"
 
 int load_obsolete_conf (pam_module_t **module_list);
 

--- a/src/supported-modules.h
+++ b/src/supported-modules.h
@@ -186,6 +186,32 @@ static pam_module_t *module_list_session[] = {
   NULL
 };
 
+static pam_module_t *module_list_session_nl[] = {
+  &mod_pam_selinux,
+  &mod_pam_mkhomedir,
+  &mod_pam_systemd_home,
+  // &mod_pam_systemd,
+  &mod_pam_limits,
+  &mod_pam_unix2,
+  &mod_pam_unix,
+  &mod_pam_apparmor,
+  &mod_pam_krb5,
+  &mod_pam_sss,
+  &mod_pam_ldap,
+  &mod_pam_winbind,
+  &mod_pam_nam,
+  &mod_pam_umask,
+  &mod_pam_ssh,
+  &mod_pam_selinux,
+  &mod_pam_gnome_keyring,
+  &mod_pam_kwallet5,
+  &mod_pam_exec,
+  &mod_pam_ecryptfs,
+  &mod_pam_env,
+  &mod_pam_mktemp,
+  NULL
+};
+
 pam_module_t *service_module_list[] = {
   &mod_pam_ck_connector,
   &mod_pam_cryptpass,


### PR DESCRIPTION
## Functions of pam_systemd

- talks to systemd-logind
  - creates a session scope unit (lifecycle, cgrp resource control,...)
  - registers a session at logind
  - starts user@.service
- sets up environment XDG_SESSION_ID and XDG_RUNTIME_DIR

## Problem

- `pam_systemd` is often invoked in situations where full-fledged session
  is not needed or even misleading
  - unneedded:
    - cron sessions where jobs runs under non-privileged UID and
      user@.service or even communication with logind is excessive
  - why misleading:
    - process is migrated out of original cgroup and systemd treats it
      as a member of a different unit (service processes migrate from
      `system.slice` to `user.slice`)
      - lifecycle mismatches (`logind.conf:KillUserProcesses=`)
      - resource control (misattributed consumption or limits)
- [list of bugs][1] historically encountered and worked around
  -  runuser/sudo not possible before autoinstall is finished
(systemd-user-sessions.service ordering)
  - frequent sudo calls increase resource usage
  - unexpected change of cgroup (due to su(do) in service scripts),
confusing for limits configuration (and killing to some extent)
- lots of cronjobs, unnecessarily many sessions created (and leaked)

## Approximate solution

- when sudo is called from an existing user session, no nesting happens
  because logind (other end of `pam_systemd`) detects it and bails out

## Solution

- Some of the involved utilites _already ship_ two PAM stack configs for
  interactive and non-interactive sessions.
- Non-internactive sessions align with cases where `pam_systemd` is
  superfluous.
- So we only need to split the `common-session` include to distinguish
  the two cases.
- Demo with accompanying [packages in OBS](https://build.opensuse.org/project/show/home:mkoutny:ALP:pam-ni) (su and crond would also need the switch to `common-session-noninteractive`).

[1]: https://mailman.suse.de/mailman/private/systemd-maintainers/2018-January/031532.html
