### PR TITLE
Add PAM aad module

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -35,7 +35,8 @@ pam_config_SOURCES = pam-config.c load_config.c write_config.c \
 	mod_pam_ecryptfs.c mod_pam_access.c mod_pam_google_authenticator.c \
 	mod_pam_kwallet5.c mod_pam_keyinit.c mod_pam_mktemp.c \
 	mod_pam_pwquality.c mod_pam_u2f.c mod_pam_faildelay.c \
-	mod_pam_lastlog2.c mod_pam_fscrypt.c mod_pam_wtmpdb.c
+	mod_pam_lastlog2.c mod_pam_fscrypt.c mod_pam_wtmpdb.c \
+	mod_pam_aad.c
 
 noinst_HEADERS = pam-config.h pam-module.h
 

--- a/src/mod_pam_aad.c
+++ b/src/mod_pam_aad.c
@@ -1,0 +1,69 @@
+/* Copyright (C) 2023 SUSE LLC
+   Author: David Mulder <dmulder@suse.com>
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License version 2 as
+   published by the Free Software Foundation.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software Foundation,
+   Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+
+#include "pam-config.h"
+#include "pam-module.h"
+
+static int
+write_config_aad (pam_module_t * this, enum write_type op, FILE * fp)
+{
+  option_set_t *opt_set = this->get_opt_set (this, op);
+
+  if (debug)
+    debug_write_call (this, op);
+
+  if (!opt_set->is_enabled (opt_set, "is_enabled"))
+    return 0;
+
+  if (op == AUTH) {
+    fprintf (fp, "auth\trequired\tpam_aad.so\t");
+  }
+
+  WRITE_CONFIG_OPTIONS
+
+  return 0;
+}
+
+GETOPT_START_ALL
+GETOPT_END_ALL
+
+PRINT_ARGS("aad")
+PRINT_XMLHELP("aad")
+
+/* ---- construct module object ---- */
+DECLARE_BOOL_OPTS_1 (is_enabled);
+DECLARE_STRING_OPTS_0;
+DECLARE_OPT_SETS;
+
+static module_helptext_t helptext[] = {{NULL, NULL, NULL}};
+
+/* at last construct the complete module object */
+pam_module_t mod_pam_aad = { "pam_aad.so", opt_sets, helptext,
+				 &def_parse_config,
+				 &def_print_module,
+				 &write_config_aad,
+				 &get_opt_set,
+				 &getopt,
+				 &print_args,
+				 &print_xmlhelp};

--- a/src/mod_pam_krb5.c
+++ b/src/mod_pam_krb5.c
@@ -30,7 +30,7 @@ static int
 write_config_krb5 (pam_module_t *this, enum write_type op, FILE *fp)
 {
   option_set_t *opt_set = this->get_opt_set (this, op);
-  int with_ldap, with_nam, with_sss, with_winbind, with_ccreds;
+  int with_ldap, with_nam, with_sss, with_winbind, with_ccreds, with_aad;
 
   if (debug)
     debug_write_call (this, op);
@@ -48,6 +48,8 @@ write_config_krb5 (pam_module_t *this, enum write_type op, FILE *fp)
 				    "pam_winbind.so", op);
   with_ccreds = is_module_enabled (common_module_list,
 				   "pam_ccreds.so", op);
+  with_aad = is_module_enabled (common_module_list,
+				"pam_aad.so", op);
   
   switch (op)
     {
@@ -92,7 +94,7 @@ write_config_krb5 (pam_module_t *this, enum write_type op, FILE *fp)
       fprintf (fp, "auth\t[default=bad]\tpam_ccreds.so\taction=update\n");
     }
 
-  if (op == AUTH && !(with_ldap || with_nam || with_sss || with_winbind))
+  if (op == AUTH && !(with_ldap || with_nam || with_sss || with_winbind || with_aad))
 	  fprintf (fp, "auth\trequired\tpam_deny.so\n");
 
   /* ldap and nam are behind this module. We write a deny

--- a/src/pam-config.8.xml
+++ b/src/pam-config.8.xml
@@ -184,7 +184,15 @@
           common-{account,auth,password,session} files
           which are included by the single service files.
         </para>
-        <variablelist>
+	<variablelist>
+          <varlistentry>
+            <term><option>--aad</option></term>
+            <listitem>
+              <para>
+                Enable/Disable pam_aad.so
+              </para>
+            </listitem>
+          </varlistentry>
           <varlistentry>
             <term><option>--access</option></term>
             <listitem>

--- a/src/supported-modules.h
+++ b/src/supported-modules.h
@@ -1,3 +1,4 @@
+extern pam_module_t mod_pam_aad;
 extern pam_module_t mod_pam_access;
 extern pam_module_t mod_pam_apparmor;
 extern pam_module_t mod_pam_ccreds;
@@ -54,6 +55,7 @@ extern pam_module_t mod_pam_systemd;
 extern pam_module_t mod_pam_u2f;
 
 pam_module_t *common_module_list[] = {
+  &mod_pam_aad,
   &mod_pam_access,
   &mod_pam_apparmor,
   &mod_pam_ccreds,
@@ -136,6 +138,7 @@ static pam_module_t *module_list_auth[] = {
   &mod_pam_ldap,
   &mod_pam_nam,
   &mod_pam_winbind,
+  &mod_pam_aad,
                    /* Attention: if you add another module behind krb5
 					  you MUST change mod_pam_krb5.c */
   NULL


### PR DESCRIPTION
This is to enable the pam aad module (Azure Active Directory). See https://github.com/ubuntu/aad-auth and the aad packages in https://build.opensuse.org/project/show/network:samba:TESTING.