### PR TITLE
Add PAM himmelblau module, remove aad

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
-AC_INIT(pam-config, 2.7)
+AC_INIT([pam-config],[2.7])
 AM_INIT_AUTOMAKE
 AC_CONFIG_SRCDIR([src/pam-config.c])
 AM_CONFIG_HEADER(config.h)
@@ -23,9 +23,9 @@ fi
 EXTRA_CFLAGS="-Werror -W -Wall -Wbad-function-cast -Wcast-align -Wcast-qual -DXTSTRINGDEFINES -Winline -Wmissing-declarations -Wmissing-prototypes -Wnested-externs -Wshadow -Wstrict-prototypes -Wundef"
 AC_SUBST(EXTRA_CFLAGS)
 dnl Checks for programs.
-AC_GNU_SOURCE
+AC_USE_SYSTEM_EXTENSIONS
 AC_PROG_CC
-AC_ISC_POSIX
+AC_SEARCH_LIBS([strerror],[cposix])
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 AC_PROG_RANLIB
@@ -71,4 +71,5 @@ AH_VERBATIM([__ZZENABLE_NLS],
 #define N_(msgid) msgid
 #endif /* ENABLE_NLS */])
 
-AC_OUTPUT([Makefile src/Makefile po/Makefile.in tests/Makefile tests/config/Makefile tests/pam-config.test/Makefile tests/etc/Makefile])
+AC_CONFIG_FILES([Makefile src/Makefile po/Makefile.in tests/Makefile tests/config/Makefile tests/pam-config.test/Makefile tests/etc/Makefile])
+AC_OUTPUT

--- a/po/Makefile.in.in
+++ b/po/Makefile.in.in
@@ -7,7 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
-# Origin: gettext-0.20.2
+# Origin: gettext-0.21
 GETTEXT_MACRO_VERSION = 0.20
 
 PACKAGE = @PACKAGE@
@@ -415,12 +415,17 @@ dist distdir:
 	@$(MAKE) dist2
 # This is a separate target because 'update-po' must be executed before.
 dist2: $(srcdir)/stamp-po $(DISTFILES)
-	dists="$(DISTFILES)"; \
+	@dists="$(DISTFILES)"; \
 	if test "$(PACKAGE)" = "gettext-tools"; then \
 	  dists="$$dists Makevars.template"; \
 	fi; \
 	if test -f $(srcdir)/$(DOMAIN).pot; then \
 	  dists="$$dists $(DOMAIN).pot stamp-po"; \
+	else \
+	  case $(XGETTEXT) in \
+	    :) echo "Warning: Creating a tarball without '$(DOMAIN).pot', because a suitable 'xgettext' program was not found in PATH." 1>&2;; \
+	    *) echo "Warning: Creating a tarball without '$(DOMAIN).pot', because 'xgettext' found no strings to extract. Check the contents of the POTFILES.in file and the XGETTEXT_OPTIONS in the Makevars file." 1>&2;; \
+	  esac; \
 	fi; \
 	if test -f $(srcdir)/ChangeLog; then \
 	  dists="$$dists ChangeLog"; \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,7 +36,7 @@ pam_config_SOURCES = pam-config.c load_config.c write_config.c \
 	mod_pam_kwallet5.c mod_pam_keyinit.c mod_pam_mktemp.c \
 	mod_pam_pwquality.c mod_pam_u2f.c mod_pam_faildelay.c \
 	mod_pam_lastlog2.c mod_pam_fscrypt.c mod_pam_wtmpdb.c \
-	mod_pam_aad.c
+	mod_pam_himmelblau.c
 
 noinst_HEADERS = pam-config.h pam-module.h
 

--- a/src/mod_pam_himmelblau.c
+++ b/src/mod_pam_himmelblau.c
@@ -26,7 +26,7 @@
 #include "pam-module.h"
 
 static int
-write_config_aad (pam_module_t * this, enum write_type op, FILE * fp)
+write_config_himmelblau (pam_module_t * this, enum write_type op, FILE * fp)
 {
   option_set_t *opt_set = this->get_opt_set (this, op);
 
@@ -36,9 +36,20 @@ write_config_aad (pam_module_t * this, enum write_type op, FILE * fp)
   if (!opt_set->is_enabled (opt_set, "is_enabled"))
     return 0;
 
-  if (op == AUTH) {
-    fprintf (fp, "auth\trequired\tpam_aad.so\t");
-  }
+  switch (op)
+    {
+    case ACCOUNT:
+      fprintf (fp, "account\trequired\tpam_himmelblau.so\tuse_first_pass\t");
+      break;
+    case AUTH:
+      fprintf (fp, "auth\trequired\tpam_himmelblau.so\tuse_first_pass\t");
+      break;
+    case SESSION:
+      fprintf (fp, "session\trequired\tpam_himmelblau.so\t");
+      break;
+    case PASSWORD:
+      break;
+    }
 
   WRITE_CONFIG_OPTIONS
 
@@ -48,21 +59,21 @@ write_config_aad (pam_module_t * this, enum write_type op, FILE * fp)
 GETOPT_START_ALL
 GETOPT_END_ALL
 
-PRINT_ARGS("aad")
-PRINT_XMLHELP("aad")
+PRINT_ARGS("himmelblau")
+PRINT_XMLHELP("himmelblau")
 
 /* ---- construct module object ---- */
-DECLARE_BOOL_OPTS_1 (is_enabled);
+DECLARE_BOOL_OPTS_2 (is_enabled, debug);
 DECLARE_STRING_OPTS_0;
 DECLARE_OPT_SETS;
 
 static module_helptext_t helptext[] = {{NULL, NULL, NULL}};
 
 /* at last construct the complete module object */
-pam_module_t mod_pam_aad = { "pam_aad.so", opt_sets, helptext,
+pam_module_t mod_pam_himmelblau = { "pam_himmelblau.so", opt_sets, helptext,
 				 &def_parse_config,
 				 &def_print_module,
-				 &write_config_aad,
+				 &write_config_himmelblau,
 				 &get_opt_set,
 				 &getopt,
 				 &print_args,

--- a/src/mod_pam_krb5.c
+++ b/src/mod_pam_krb5.c
@@ -30,7 +30,7 @@ static int
 write_config_krb5 (pam_module_t *this, enum write_type op, FILE *fp)
 {
   option_set_t *opt_set = this->get_opt_set (this, op);
-  int with_ldap, with_nam, with_sss, with_winbind, with_ccreds, with_aad;
+  int with_ldap, with_nam, with_sss, with_winbind, with_ccreds, with_himmelblau;
 
   if (debug)
     debug_write_call (this, op);
@@ -48,8 +48,8 @@ write_config_krb5 (pam_module_t *this, enum write_type op, FILE *fp)
 				    "pam_winbind.so", op);
   with_ccreds = is_module_enabled (common_module_list,
 				   "pam_ccreds.so", op);
-  with_aad = is_module_enabled (common_module_list,
-				"pam_aad.so", op);
+  with_himmelblau = is_module_enabled (common_module_list,
+				       "pam_himmelblau.so", op);
   
   switch (op)
     {
@@ -94,7 +94,7 @@ write_config_krb5 (pam_module_t *this, enum write_type op, FILE *fp)
       fprintf (fp, "auth\t[default=bad]\tpam_ccreds.so\taction=update\n");
     }
 
-  if (op == AUTH && !(with_ldap || with_nam || with_sss || with_winbind || with_aad))
+  if (op == AUTH && !(with_ldap || with_nam || with_sss || with_winbind || with_himmelblau))
 	  fprintf (fp, "auth\trequired\tpam_deny.so\n");
 
   /* ldap and nam are behind this module. We write a deny

--- a/src/pam-config.8.xml
+++ b/src/pam-config.8.xml
@@ -186,14 +186,6 @@
         </para>
         <variablelist>
           <varlistentry>
-            <term><option>--aad</option></term>
-            <listitem>
-              <para>
-                Enable/Disable pam_aad.so
-              </para>
-            </listitem>
-          </varlistentry>
-          <varlistentry>
             <term><option>--access</option></term>
             <listitem>
               <para>
@@ -650,6 +642,14 @@
             </listitem>
           </varlistentry>
           <varlistentry>
+            <term><option>--himmelblau</option></term>
+            <listitem>
+              <para>
+                Enable/Disable pam_himmelblau.so
+              </para>
+            </listitem>
+          </varlistentry>
+	  <varlistentry>
             <term><option>--krb5</option></term>
             <listitem>
               <para>

--- a/src/supported-modules.h
+++ b/src/supported-modules.h
@@ -1,4 +1,4 @@
-extern pam_module_t mod_pam_aad;
+extern pam_module_t mod_pam_himmelblau;
 extern pam_module_t mod_pam_access;
 extern pam_module_t mod_pam_apparmor;
 extern pam_module_t mod_pam_ccreds;
@@ -55,7 +55,7 @@ extern pam_module_t mod_pam_systemd;
 extern pam_module_t mod_pam_u2f;
 
 pam_module_t *common_module_list[] = {
-  &mod_pam_aad,
+  &mod_pam_himmelblau,
   &mod_pam_access,
   &mod_pam_apparmor,
   &mod_pam_ccreds,
@@ -138,7 +138,7 @@ static pam_module_t *module_list_auth[] = {
   &mod_pam_ldap,
   &mod_pam_nam,
   &mod_pam_winbind,
-  &mod_pam_aad,
+  &mod_pam_himmelblau,
                    /* Attention: if you add another module behind krb5
 					  you MUST change mod_pam_krb5.c */
   NULL


### PR DESCRIPTION
I previously added the aad module, but our team
has since abandoned the module in favor of our
own implementation, called himmelblau. Himmelblau
also provides Azure AD authentication, but is
written in Rust and provides many more features
not found in aad.