### PR TITLE
pam_gnome_keyring: use option in AUTH

### DIFF
--- a/src/mod_pam_gnome_keyring.c
+++ b/src/mod_pam_gnome_keyring.c
@@ -40,9 +40,7 @@ write_config_gnome_keyring (pam_module_t *this, enum write_type op, FILE *fp)
   switch (op)
     {
     case AUTH:
-      /* No options: we put the auto_start options in SESSION only */
-      fprintf (fp, "auth\toptional\tpam_gnome_keyring.so\n");
-      return 0;
+      fprintf (fp, "auth\toptional\tpam_gnome_keyring.so\t");
       break;
     case ACCOUNT:
       return 0;
@@ -65,6 +63,13 @@ write_config_gnome_keyring (pam_module_t *this, enum write_type op, FILE *fp)
 }
 
 GETOPT_START_ALL
+  /* We put the auto_start options in SESSION only */
+  else if (strcmp ("auto_start", opt) == 0) {
+    opt_set = this->get_opt_set (this, SESSION);
+    if (opt_set->enable (opt_set, opt, g_opt->opt_val) == FALSE) {
+      return 1;
+    }
+  }
 GETOPT_END_ALL
 
 PRINT_ARGS("gnome_keyring");


### PR DESCRIPTION
* As auto_start_if option has been split into two options auto_start and only_if, Instead of remove all options for AUTH, just remove the auto_start to have it only on SESSION.
* If "only_if=services" option is only set in SESSION, all services will still call the module gnome_keyring due to this presence in AUTH without this filter. (bsc#1219767)