### PR TITLE
Place himmelblau near the top of pam stack

### DIFF
--- a/src/mod_pam_himmelblau.c
+++ b/src/mod_pam_himmelblau.c
@@ -29,7 +29,6 @@ static int
 write_config_himmelblau (pam_module_t * this, enum write_type op, FILE * fp)
 {
   option_set_t *opt_set = this->get_opt_set (this, op);
-  int with_winbind, with_ldap, with_sss;
 
   if (debug)
     debug_write_call (this, op);
@@ -37,30 +36,19 @@ write_config_himmelblau (pam_module_t * this, enum write_type op, FILE * fp)
   if (!opt_set->is_enabled (opt_set, "is_enabled"))
     return 0;
 
-  with_winbind = is_module_enabled(common_module_list, "pam_winbind.so", op);
-  with_ldap = is_module_enabled(common_module_list, "pam_ldap.so", op);
-  with_sss = is_module_enabled(common_module_list, "pam_sss.so", op);
-
   switch (op)
     {
     case ACCOUNT:
-      if (with_winbind || with_ldap || with_sss) {
-        fprintf (fp, "account\tsufficient\tpam_himmelblau.so\tuse_first_pass\t");
-      } else {
-        fprintf (fp, "account\trequired\tpam_himmelblau.so\tuse_first_pass\t");
-      }
+      fprintf (fp, "account\trequired\tpam_himmelblau.so\tignore_unknown_user\t");
       break;
     case AUTH:
-      if (with_winbind || with_ldap || with_sss) {
-        fprintf (fp, "auth\tsufficient\tpam_himmelblau.so\tuse_first_pass\t");
-      } else {
-        fprintf (fp, "auth\trequired\tpam_himmelblau.so\tuse_first_pass\t");
-      }
+      fprintf (fp, "auth\tsufficient\tpam_himmelblau.so\tignore_unknown_user\t");
       break;
     case SESSION:
       fprintf (fp, "session\toptional\tpam_himmelblau.so\t");
       break;
     case PASSWORD:
+      fprintf (fp, "password\tsufficient\tpam_himmelblau.so\tignore_unknown_user\t");
       break;
     }
 

--- a/src/mod_pam_unix.c
+++ b/src/mod_pam_unix.c
@@ -30,7 +30,7 @@ write_config_unix (pam_module_t *this, enum write_type op, FILE *fp)
 {
   option_set_t *opt_set = this->get_opt_set (this, op);
   int with_krb5, with_ldap, with_lum, with_winbind, with_pwcheck,
-    with_cracklib, with_mount, with_sss, with_himmelblau;
+    with_cracklib, with_mount, with_sss;
 
   if (debug)
     debug_write_call (this, op);
@@ -43,7 +43,6 @@ write_config_unix (pam_module_t *this, enum write_type op, FILE *fp)
   with_lum	= is_module_enabled (common_module_list, "pam_lum.so"	  , op);
   with_winbind	= is_module_enabled (common_module_list, "pam_winbind.so" , op);
   with_sss	= is_module_enabled (common_module_list, "pam_sss.so"	  , op);
-  with_himmelblau = is_module_enabled (common_module_list, "pam_himmelblau.so", op);
   with_pwcheck	= is_module_enabled (common_module_list, "pam_pwcheck.so" , op);
   with_cracklib = is_module_enabled (common_module_list, "pam_cracklib.so", op);
   with_mount	= is_module_enabled (common_module_list, "pam_mount.so"	  , op);
@@ -51,7 +50,7 @@ write_config_unix (pam_module_t *this, enum write_type op, FILE *fp)
   switch (op)
   {
     case AUTH:
-      if (with_krb5 || with_ldap || with_lum || with_winbind || with_sss || with_himmelblau)
+      if (with_krb5 || with_ldap || with_lum || with_winbind || with_sss)
 	/* Only sufficient if other modules follow */
 	fprintf (fp, "auth\tsufficient\tpam_unix.so\t");
       else
@@ -63,7 +62,7 @@ write_config_unix (pam_module_t *this, enum write_type op, FILE *fp)
 	opt_set->enable (opt_set, "use_first_pass", TRUE);
       break;
     case ACCOUNT:
-      if (with_krb5 || with_ldap || with_lum || with_winbind || with_sss || with_himmelblau)
+      if (with_krb5 || with_ldap || with_lum || with_winbind || with_sss)
 	fprintf (fp, "account\trequisite\tpam_unix.so\t");
       else
 	fprintf (fp, "account\trequired\tpam_unix.so\t");

--- a/src/supported-modules.h
+++ b/src/supported-modules.h
@@ -106,6 +106,7 @@ pam_module_t *common_module_list[] = {
 static pam_module_t *module_list_account[] = {
   &mod_pam_access,
   &mod_pam_systemd_home,
+  &mod_pam_himmelblau,
   &mod_pam_unix2,
   &mod_pam_unix,
   &mod_pam_krb5,
@@ -115,7 +116,6 @@ static pam_module_t *module_list_account[] = {
   &mod_pam_nam,
   &mod_pam_winbind,
   &mod_pam_time,
-  &mod_pam_himmelblau,
   &mod_pam_kanidm,
   NULL
 };
@@ -129,6 +129,7 @@ static pam_module_t *module_list_auth[] = {
   &mod_pam_fprint,
   &mod_pam_fprintd,
   &mod_pam_thinkfinger,
+  &mod_pam_himmelblau,
   &mod_pam_gnome_keyring,
   &mod_pam_kwallet5, /* optional modules MUST be executed before sufficient modules which also need a password. */
   &mod_pam_systemd_home,
@@ -142,7 +143,6 @@ static pam_module_t *module_list_auth[] = {
   &mod_pam_ldap,
   &mod_pam_nam,
   &mod_pam_winbind,
-  &mod_pam_himmelblau,
   &mod_pam_kanidm,
                    /* Attention: if you add another module behind krb5
 					  you MUST change mod_pam_krb5.c */
@@ -150,6 +150,7 @@ static pam_module_t *module_list_auth[] = {
 };
 
 static pam_module_t *module_list_password[] = {
+  &mod_pam_himmelblau,
   &mod_pam_winbind,
   &mod_pam_pwcheck,
   &mod_pam_passwdqc,


### PR DESCRIPTION
Himmelblau needs to be at or near the top of the
pam stack, otherwise we have two problems:
First, pam_unix prevents pam account for
himmelblau from running.
Second, other pam modules prompt for a password
(pam_unix, gnome_keyring, etc) before himmelblau
has had the chance to send the correct prompt
(which could be MFA, Hello PIN, etc).

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1243418